### PR TITLE
Allow the game/basic test to run to completion

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2807,6 +2807,8 @@ struct chunk *town_gen(struct player *p, int min_height, int min_width)
 		c_new->depth = c_old->depth;
 		if (!chunk_copy(c_new, p, c_old, 0, 0, 0, 0))
 			quit_fmt("chunk_copy() level bounds failed!");
+		chunk_list_remove(p->town->name);
+		cave_free(c_old);
 
 		/* Find the stairs (lame) */
 		if (!found) {

--- a/src/init.c
+++ b/src/init.c
@@ -4000,6 +4000,7 @@ static void cleanup_class(void)
 		mem_free(c);
 		c = next;
 	}
+	total_spells = 0;
 }
 
 static struct file_parser class_parser = {

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -648,7 +648,6 @@ void wipe_mon_list(struct chunk *c, struct player *p)
 				 */
 				if (obj->oidx) {
 					c->objects[obj->oidx] = NULL;
-					obj->oidx = 0;
 				}
 				obj = obj->next;
 			}


### PR DESCRIPTION
Another change, up as [this pull request](https://github.com/angband/angband/pull/5091) against Angband, is also necessary to avoid the test encountering a segmentation fault in cave_free().

With those, the game/basic test runs to completion.  Two of its tests fail (test_stairs1() and test_stairs2()).  I didn't track down why.  Perhaps the prompt that's displayed when first entering a dungeon is the cause.